### PR TITLE
Filter out unicode [Sc-15993]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propra/mdpdfmake",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@propra/mdpdfmake",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "@types/marked": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { pdfMakeCodeblock } from "./utils/codeblock";
 import { pdfMakeHR } from "./utils/hr";
 import { MOptions } from "./types";
 import { globalOptions } from "./globalOptions";
+import { cleanUnicodefromText } from "./utils/utils";
 
 async function mdpdfmake(
   markdown: string,
@@ -35,7 +36,7 @@ async function mdpdfmake(
     }
   }
 
-  const tokens = lexer(markdown);
+  const tokens = lexer(cleanUnicodefromText(markdown));
   const content: any[] = [];
 
   for (const token of tokens) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,7 @@
+const unicodes = ["&#x20;"];
+export const cleanUnicodefromText = (text: string) => {
+  unicodes.forEach((unicode) => {
+    text = text.replaceAll(unicode, "");
+  });
+  return text;
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,8 @@
-const unicodes = ["&#x20;"];
+const unicodes = [{ code: "&#x20;", replace: " " }];
+
 export const cleanUnicodefromText = (text: string) => {
-  unicodes.forEach((unicode) => {
-    text = text.replaceAll(unicode, "");
+  unicodes.forEach(({ code, replace }) => {
+    text = text.replaceAll(code, replace);
   });
   return text;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2021",
     "moduleResolution": "bundler",
     "outDir": "dist"
   },


### PR DESCRIPTION
Why was this PR opened?
MDXEditor is sending some unicode that doesnt get converted

Brief Description
just filter them out

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a new utility function `cleanUnicodefromText` to clean specific unicode characters from text inputs.
- Enhanced markdown processing by applying `cleanUnicodefromText` to the markdown input before tokenization in `src/index.ts`.
- Updated TypeScript compilation target to "es2021" for better compatibility and modern syntax support in `tsconfig.json`.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Enhance Markdown Processing by Cleaning Unicode Characters</code></dd></summary>
<hr>
      
src/index.ts

<li>Imported <code>cleanUnicodefromText</code> from <code>./utils/utils</code>.<br> <li> Applied <code>cleanUnicodefromText</code> to the markdown input before <br>tokenization.<br>


</details>
    

  </td>
  <td><a href="https:/propra-tech/mdpdfmake/pull/5/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Utility Function to Clean Unicode Characters from Text</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/utils/utils.ts

<li>Added <code>cleanUnicodefromText</code> function to remove specific unicode <br>characters from text.<br> <li> Defined a list of unicode characters to be removed.<br>


</details>
    

  </td>
  <td><a href="https:/propra-tech/mdpdfmake/pull/5/files#diff-5acab41990585fa68ae01ff7b2e2915628d19237840c3061b31fcadc1c0f09b8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tsconfig.json</strong><dd><code>Update TypeScript Compilation Target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tsconfig.json

- Updated TypeScript target from "es6" to "es2021".



</details>
    

  </td>
  <td><a href="https:/propra-tech/mdpdfmake/pull/5/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

